### PR TITLE
Add workflows and update setup

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,64 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      main
+
+jobs:
+  build:
+    if: ${{ github.repository_owner == 'cosmicds' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.17.1'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build
+
+          # - name: BrowserStack env setup
+          #   uses: browserstack/github-actions/setup-env@master
+          #   with:
+          #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+          # - name: BrowserStack local tunnel setup
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: start
+          #     local-identifier: random
+
+          # - name: Run BrowserStack tests
+          #   run: |
+          #     set -xeuo pipefail
+          #     yarn serve &
+          #     sleep 10
+          #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+
+      - name: Check for draft flag
+        uses: sergeysova/jq-action@v2
+        id: draft
+        with:
+          cmd: cat package.json | jq -r '.draft // false'
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ steps.draft.outputs.value }} == 'true'
+        with:
+          branch: gh-pages
+          folder: dist
+          ssh-key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build
+
+on:
+  pull_request_target:
+    branches:
+      main
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+    
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.17.1'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build
+
+          # - name: BrowserStack env setup
+          #   uses: browserstack/github-actions/setup-env@master
+          #   with:
+          #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+          # - name: 'BrowserStack local tunnel setup'
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: start
+          #     local-identifier: random
+
+          # - name: Run BrowserStack tests
+          #   run: |
+          #     set -xeuo pipefail
+          #     yarn serve &
+          #     sleep 10
+          #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+
+          # - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: stop

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ If you get complaints that the script isn't executable, make it so by running `c
     - To preview the story using the development server, run `yarn serve`
     - To build the story for production use, run `yarn build`
 
-## Deployment
+## Deployment and Github Actions
 
-The built story is just a set of HTML/CSS/JS + any assets that you add, so it should be easy to host anywhere. One simple way to host a story is using Github Pages, which provides a free static site hosting service for public repositories. This can even be done automatically using Github Actions - see the `build-deploy` in the [Carina data story](https://github.com/cosmicds/carinads) for an example.
+The built story is just a set of HTML/CSS/JS + any assets that you add, so it should be easy to host anywhere. One simple way to host a story is using Github Pages, which provides a free static site hosting service for public repositories. This repository provides two workflows (see the `.github/workflows` directory) to help with this:
+* `build.yml` - on a pull request, build the PR version of the story (to test that it at least builds successfully)
+* `build-deploy.yml` - on a commit to main, build the story and push the built version to the `gh-pages` branch. This built version can then be deployed to Github Pages in the repository settings: `Settings > Pages`, then choose `Deploy from a branch` and use the `gh-pages` branch.
 
 ## BrowserStack testing - CosmicDS team
 
-If you're a member of the CosmicDS team, we can perform E2E testing (both locally and in Github Actions) using BrowserStack. See the tests in the [Carina data story](https://github.com/cosmicds/carinads) as an example. Note that you'll need to have our BrowserStack username and access key for this to work correctly.
+If you're a member of the CosmicDS team, we can perform E2E testing (both locally and in Github Actions) using BrowserStack. To activate this testing, uncomment the relevant pieces in the provided workflows. Note that you'll need to have our BrowserStack username and access key for this to work correctly. (If the repository that you're working on is part of the CosmicDS organization, you shouldn't need to add these at the repository level).

--- a/public/index.html
+++ b/public/index.html
@@ -16,10 +16,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://cosmicds.github.io/minids-template/">
-  <meta property="og:title" content="MiniDS data story template">
-  <meta property="og:description"
-    content="MiniDS data story template">
-  <meta property="og:site_name" content="MiniDS data story template">
+  <meta property="og:title" content="CosmicDS data story template">
+  <meta property="og:description" content="CosmicDS data story template">
+  <meta property="og:site_name" content="CosmicDS data story template">
   <meta property="og:image" content="https://cosmicds.github.io/minids-template/preview.png">
   <meta property="og:image:secure_url" content="https://cosmicds.github.io/minids-template/preview.png">
   <meta property="og:image:type" content="image/jpeg">
@@ -31,7 +30,7 @@
   <meta name="twitter:creator" content="@CosmicDataStory">
   <meta name="twitter:image" content="https://cosmicds.github.io/minids-template/preview.png">
   <link rel="icon" href="https://cosmicds.github.io/cds-website/cosmicds-favicon.png">
-  <title>MiniDS Template</title>
+  <title>CosmicDS Template</title>
 </head>
 
 <body>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,4 +41,4 @@ rm -f index.html.bak
 
 # Clear out git info since we don't want this to point to the vue-ds-template repo anymore
 cd ..
-rm -r .git
+rm -rf .git

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,7 @@ function space_split_pascal {
 }
 
 if [[ $# -lt 1 ]]; then
-    echo "Mini name is missing!"
+    echo "Story name is missing!"
     exit 2
 fi
 if [[ $# -gt 1 ]]; then
@@ -23,23 +23,22 @@ fi
 
 name=$1
 
-if [[ -d $name ]] | [[ -h $name ]]; then
-    echo "A directory for this mini already exists!"
-    exit 2
-fi
-
-node scripts/update-name.js "@minids/${name}"
+node scripts/update-name.js "@cosmicds/${name}"
 pascal_case_name=$(to_pascal_case $name)
 title=$(space_split_pascal ${pascal_case_name})
 
 cd src
 sed -i.bak "s/MainComponent/${pascal_case_name}/g" main.ts
-sed -i.bak "s/wwt-minids-template/wwt-minids-$name/g" main.ts
+sed -i.bak "s/wwt-minids-template/$name/g" main.ts
 rm -f main.ts.bak
 mv MainComponent.vue ${pascal_case_name}.vue
 
 cd ../public
 sed -i.bak "s/minids-template/$name/g" index.html
-sed -i.bak "s/MiniDS data story template/$pascal_case_name/g" index.html
-sed -i.bak "s/MiniDS Template/$title/g" index.html
+sed -i.bak "s/CosmicDS data story template/$pascal_case_name/g" index.html
+sed -i.bak "s/CosmicDS Template/$title/g" index.html
 rm -f index.html.bak
+
+# Clear out git info since we don't want this to point to the vue-ds-template repo anymore
+cd ..
+rm -r .git


### PR DESCRIPTION
This PR makes a few changes:
* Adds the build/deploy workflows that we've used in other stories to the template. If a story doesn't want to use Github Actions, they can always be deleted
* Update the README with information about these workflows
* Update the setup script to remove `.git`, so that it isn't still referencing this repository
* Update some of the default text in the `index.html` file