### PR TITLE
Update favicon domain

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@CosmicDataStory">
   <meta name="twitter:image" content="https://cosmicds.github.io/minids-template/preview.png">
-  <link rel="icon" href="https://cosmicds.github.io/cds-website/cosmicds-favicon.png">
+  <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
   <title>CosmicDS Template</title>
 </head>
 


### PR DESCRIPTION
This PR updates the domain in the favicon URL in the template index file. This will let favicons in stories deployed on the CosmicDS organization GitHub Pages display correctly.