### PR TITLE
Improve layout of main component and add splash screen parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "draft": true,
   "version": "0.0.0",
   "dependencies": {
-    "@cosmicds/vue-toolkit": "^0.1.3",
+    "@cosmicds/vue-toolkit": "^0.2.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/vue-fontawesome": "^3.0.5",

--- a/public/index.html
+++ b/public/index.html
@@ -15,12 +15,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://projects.cosmicds.cfa.harvard.edu/minids-template/">
-  <meta property="og:title" content="CosmicDS data story template">
-  <meta property="og:description" content="CosmicDS data story template">
-  <meta property="og:site_name" content="CosmicDS data story template">
-  <meta property="og:image" content="https://projects.cosmicds.cfa.harvard.edu/minids-template/preview.png">
-  <meta property="og:image:secure_url" content="https://projects.cosmicds.cfa.harvard.edu/minids-template/preview.png">
+  <meta property="og:url" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/">
+  <meta property="og:title" content="CosmicDS Vue template">
+  <meta property="og:description" content="CosmicDS Vue template">
+  <meta property="og:site_name" content="CosmicDS Vue template">
+  <meta property="og:image" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
+  <meta property="og:image:secure_url" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <meta property="og:image:type" content="image/jpeg">
   <meta property="og:image:width" content="596">
   <meta property="og:image:height" content="886">
@@ -28,9 +28,9 @@
   <meta name="twitter:site" content="@CosmicDataStory">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@CosmicDataStory">
-  <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/minids-template/preview.png">
+  <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
-  <title>CosmicDS Template</title>
+  <title>CosmicDS Vue Template</title>
 </head>
 
 <body>

--- a/src/MainComponent.vue
+++ b/src/MainComponent.vue
@@ -495,6 +495,12 @@ body {
   align-items: flex-start;
 }
 
+#left-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 #bottom-content {
   display: flex;
   flex-direction: column;

--- a/src/MainComponent.vue
+++ b/src/MainComponent.vue
@@ -263,8 +263,9 @@ export default defineComponent({
     }
   },
   data() {
+    const showSplashScreen = new URLSearchParams(window.location.search).get("splash")?.toLowerCase() !== "false";
     return {
-      showSplashScreen: true,
+      showSplashScreen,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,

--- a/src/MainComponent.vue
+++ b/src/MainComponent.vue
@@ -517,7 +517,7 @@ body {
 
 #splash-screen {
   color: #FFFFFF;
-  background-color: #FFFFFF;
+  background-color: #000000;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;

--- a/src/MainComponent.vue
+++ b/src/MainComponent.vue
@@ -30,15 +30,15 @@
           @click="closeSplashScreen"
           >&times;
         </div>
-      </div>
-      <div id="splash-screen-text">
-        <p>Splash Screen text</p>
-      </div>
-      <div id="splash-screen-acknowledgements">
-        This Mini Data Story is brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer">WorldWide Telescope</a>.
-        
-        <div id="splash-screen-logos">
-          <credit-logos/>
+        <div id="splash-screen-text">
+          <p>Splash Screen Content</p>
+        </div>
+        <div id="splash-screen-acknowledgements" class="small">
+          This Data Story is brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer">WorldWide Telescope</a>.
+          
+          <div id="splash-screen-logos">
+            <credit-logos logo-size="5vmin"/>
+          </div>
         </div>
       </div>
     </v-overlay>
@@ -59,7 +59,7 @@
 
     <!-- This block contains the elements (e.g. icon buttons displayed at/near the top of the screen -->
 
-    <div class="top-content">
+    <div id="top-content">
       <div id="left-buttons">
         <icon-button
           v-model="showTextSheet"
@@ -87,7 +87,7 @@
 
     <!-- This block contains the elements (e.g. the project icons) displayed along the bottom of the screen -->
 
-    <div class="bottom-content">
+    <div id="bottom-content">
       <div id="body-logos" v-if= "!smallSize">
         <credit-logos/>
       </div>
@@ -375,7 +375,309 @@ export default defineComponent({
 </script>
 
 <style lang="less">
+@font-face {
+  font-family: "Highway Gothic Narrow";
+  src: url("https://projects.cosmicds.cfa.harvard.edu/cds-website/fonts/HighwayGothicNarrow.ttf");
+}
+
+:root {
+  --default-font-size: clamp(0.7rem, min(1.7vh, 1.7vw), 1.1rem);
+  --default-line-height: clamp(1rem, min(2.2vh, 2.2vw), 1.6rem);
+}
+
+html {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background-color: #000;
+  overflow: hidden;
+
+  
+  -ms-overflow-style: none;
+  // scrollbar-width: none;
+}
+
+body {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+
+  font-family: Verdana, Arial, Helvetica, sans-serif;
+}
+
+#main-content {
+  position: fixed;
+  width: 100%;
+  height: var(--app-content-height);
+  overflow: hidden;
+
+  transition: height 0.1s ease-in-out;
+}
+
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  font-size: 11pt;
+
+  .wwtelescope-component {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    border-style: none;
+    border-width: 0;
+    margin: 0;
+    padding: 0;
+  }
+}
+
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s;
+}
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.modal {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#modal-loading {
+  background-color: #000;
+  .container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    .spinner {
+      background-image: url("https://projects.cosmicds.cfa.harvard.edu/cds-website/misc/lunar_loader.gif");
+      background-repeat: no-repeat;
+      background-size: contain;
+      width: 3rem;
+      height: 3rem;
+    }
+    p {
+      margin: 0 0 0 1rem;
+      padding: 0;
+      font-size: 150%;
+    }
+  }
+}
+
+#top-content {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  width: calc(100% - 2rem);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: flex-start;
+}
+
+#bottom-content {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  width: calc(100% - 2rem);
+  pointer-events: none;
+  align-items: center;
+  gap: 5px;
+}
+
+#splash-overlay {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
 #splash-screen {
   color: #FFFFFF;
+  background-color: #FFFFFF;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  align-content: center;
+  justify-content: space-around;
+
+  font-family: 'Highway Gothic Narrow', 'Roboto', sans-serif;
+  font-size: min(8vw, 7vh);
+
+  border-radius: 10%;
+  border: min(1.2vw, 0.9vh) solid var(--accent-color);
+  overflow: auto;
+  padding-top: 4rem;
+  padding-bottom: 1rem;
+
+  @media (max-width: 699px) {
+    max-height: 80vh;
+    max-width: 90vw;
+  }
+
+  @media (min-width: 700px) {
+    max-height: 85vh;
+    max-width: min(70vw, 800px);
+  }
+
+  div {
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .small {
+    font-size: var(--default-font-size);
+    font-weight: bold;
+  }
+
+  #close-splash-button {
+    position: absolute;
+    top: 0.5rem;
+    right: 1.75rem;
+    text-align: end;
+    color: var(--accent-color);
+    font-size: min(8vw, 5vh);
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
+
+.video-wrapper {
+  height: 100%;
+  background: black;
+  text-align: center;
+  z-index: 1000;
+
+  #video-close-icon {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 15;
+    
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:focus {
+      color: white;
+      border: 2px solid white;
+    }
+  }
+}
+
+video {
+  height: 100%;
+  width: auto;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+#info-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0px;
+  z-index: 10;
+}
+
+.bottom-sheet {
+  .v-overlay__content {
+    align-self: flex-end;
+    padding: 0;
+    margin: 0;
+    max-width: 100%;
+    height: 34%;
+  }
+
+  #tabs {
+    width: calc(100% - 3em);
+    align-self: left;
+  }
+  
+  .info-text {
+    height: 33vh;
+    padding-bottom: 25px;
+  
+    & a {
+      text-decoration: none;
+    }
+  }
+  
+  .close-icon {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 15;
+  
+    &:hover {
+      cursor: pointer;
+    }
+  
+    &:focus {
+      color: white;
+      border: 2px solid white;
+    }
+  }
+  
+  .scrollable {
+    overflow-y: auto;
+  }
+  
+  #tab-items {
+    // padding-bottom: 2px !important;
+  
+    .v-card-text {
+      font-size: ~"max(14px, calc(0.7em + 0.3vw))";
+      padding-top: ~"max(2vw, 16px)";
+      padding-left: ~"max(4vw, 16px)";
+      padding-right: ~"max(4vw, 16px)";
+  
+      .end-spacer {
+        height: 25px;
+      }
+    }
+  
+  }
+  
+  #close-text-icon {
+    position: absolute;
+    top: 0.25em;
+    right: calc((3em - 0.6875em) / 3); // font-awesome-icons have width 0.6875em
+    color: white;
+  }
+
+  // This prevents the tabs from having some extra space to the left when the screen is small
+  // (around 400px or less)
+  .v-tabs:not(.v-tabs--vertical).v-tabs--right>.v-slide-group--is-overflowing.v-tabs-bar--is-mobile:not(.v-slide-group--has-affixes) .v-slide-group__next, .v-tabs:not(.v-tabs--vertical):not(.v-tabs--right)>.v-slide-group--is-overflowing.v-tabs-bar--is-mobile:not(.v-slide-group--has-affixes) .v-slide-group__prev {
+    display: none;
+  }
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,14 +203,14 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@cosmicds/vue-toolkit@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@cosmicds/vue-toolkit/-/vue-toolkit-0.1.3.tgz#c29b8c42bb82cd274a7468fba433c6312ef167a6"
-  integrity sha512-D+z2l7x1JqD2RLFgf/pkA3DitIN4/7duGXfsBuAEFM9Kq52cw3Irso57Cw5ud3x3zkWGb0PHN3/jYk0GIVapYw==
+"@cosmicds/vue-toolkit@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@cosmicds/vue-toolkit/-/vue-toolkit-0.2.0.tgz#23defa1c9a22a9a382c8f658d1e077b9772e862d"
+  integrity sha512-pjBJuraz7+drlerqiE2o1eRzD/wH2qScZKYLQRcCwAV9f+vNulGLT4XARxlpTyfe+rC1YF0GpJWzNCIRmBwBDQ==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.1"
     "@fortawesome/free-solid-svg-icons" "^6.5.1"
-    "@fortawesome/vue-fontawesome" "^3.0.3"
+    "@fortawesome/vue-fontawesome" "^3.0.6"
     "@kyvg/vue3-notification" "^2.9.1"
     "@mdi/font" "^7.4.47"
     "@wwtelescope/engine-pinia" "^0.9.0"
@@ -275,10 +275,15 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.5.1"
 
-"@fortawesome/vue-fontawesome@^3.0.3", "@fortawesome/vue-fontawesome@^3.0.5":
+"@fortawesome/vue-fontawesome@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.5.tgz#fef21fbb0277711160f9105e8e5bb9a15f5fce25"
   integrity sha512-isZZ4+utQH9qg9cWxWYHQ9GwI3r5FeO7GnmzKYV+gbjxcptQhh+F99iZXi1Y9AvFUEgy8kRpAdvDlbb3drWFrw==
+
+"@fortawesome/vue-fontawesome@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.6.tgz#c5e627475c10869a091280610c96411d18206f3a"
+  integrity sha512-akrL7lTroyNpPkoHtvK2UpsMzJr6jXdHaQ0YdcwqDsB8jdwlpNHZYijpOUd9KJsARr+VB3WXY4EyObepqJ4ytQ==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"


### PR DESCRIPTION
This PR adds some CSS to help set up the layout of the main template component. Most of this is taken from existing stories, and helps make this template be out-of-the-box ready.

Additionally, this resolves #5 by adding a `splash` query parameter to allow not displaying the splash screen, which is another feature that we've frequently implemented in our current stories.

Note that this anticipates the logo CSS added in https://github.com/cosmicds/vue-toolkit/pull/2.