### PR TITLE
Add icon link tags and manifest file

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,13 @@
   <meta name="twitter:creator" content="@CosmicDataStory">
   <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/vue-ds-template/preview.png">
   <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
+  <link rel="apple-touch-icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-57.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-72.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-114.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-144.png">
+  <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.ico">
+  <meta name="apple-mobile-web-app-title" content="CosmicDS Vue Template">
+  <link rel="manifest" href="site.webmanifest">
   <title>CosmicDS Vue Template</title>
 </head>
 

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,4 @@
+{
+  "name": "Cosmic Data Stories: CosmicDS Vue Template",
+  "short_name": "CosmicDS Vue Template"
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,8 +36,11 @@ mv MainComponent.vue ${pascal_case_name}.vue
 cd ../public
 sed -i.bak "s/minids-template/$name/g" index.html
 sed -i.bak "s/CosmicDS data story template/$pascal_case_name/g" index.html
-sed -i.bak "s/CosmicDS Template/$title/g" index.html
+sed -i.bak "s/CosmicDS Vue template/$title/g" index.html
+sed -i.bak "s/CosmicDS Vue Template/$title/g" index.html
+sed -i.bak "s/CosmicDS Vue Template/$title/g" site.webmanifest
 rm -f index.html.bak
+rm -f site.webmanifest.bak
 
 # Clear out git info since we don't want this to point to the vue-ds-template repo anymore
 cd ..


### PR DESCRIPTION
This PR updates the index file to use the CosmicDS icon for mobile shortcuts on Android and iOS, as well as set the shortcut title (via the index for iOS, and the manifest file on Android).