### PR TITLE
Don't use Google Analytics on a local network

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,12 +4,12 @@
 <head>
   <!-- Google Analytics -->
   <script>
+    // Logic derived from https://stackoverflow.com/a/61839170
     const local = (function (hostname=window.location.hostname) {
       return (
         (['localhost', '127.0.0.1', '', '::1'].includes(hostname))
         || (hostname.startsWith('192.168.'))
         || (hostname.startsWith('10.'))
-        || (hostname.endsWith('.local'))
       )
     })();
     if (!local) {

--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,27 @@
 <html lang="en">
 
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-C2ELSYY9VC"></script>
+  <!-- Google Analytics -->
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    const local = (function (hostname=window.location.hostname) {
+      return (
+        (['localhost', '127.0.0.1', '', '::1'].includes(hostname))
+        || (hostname.startsWith('192.168.'))
+        || (hostname.startsWith('10.'))
+        || (hostname.endsWith('.local'))
+      )
+    })();
+    if (!local) {
+      const script = document.createElement("script");
+      script.async = true;
+      script.src = "https://www.googletagmanager.com/gtag/js?id=G-C2ELSYY9VC";
+      document.head.appendChild(script);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
   
-    gtag('config', 'G-C2ELSYY9VC');
+      gtag('config', 'G-C2ELSYY9VC');
+    }
   </script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
This PR updates the main HTML skeleton of the template to not use Google Analytics if we're on a "local network", using some logic that should look for general local networks. This isn't bulletproof, but should handle the "this is running on my local Vue dev server" type of things that we're looking to avoid.