### PR TITLE
Update setup script to rename component props

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,6 +29,7 @@ title=$(space_split_pascal ${pascal_case_name})
 
 cd src
 sed -i.bak "s/MainComponent/${pascal_case_name}/g" main.ts
+sed -i.bak "s/MainComponent/${pascal_case_name}/g" MainComponent.vue
 sed -i.bak "s/wwt-minids-template/$name/g" main.ts
 rm -f main.ts.bak
 mv MainComponent.vue ${pascal_case_name}.vue


### PR DESCRIPTION
Now that we've switched over to the Composition API, we now have an interface for the component props, which in the template is `MainComponentProps`. Currently this isn't getting renamed by the setup script because we aren't touching the component file. This PR updates the setup script so that the props, as well as the WWT namespace, get renamed properly.