### PR TITLE
Make sure that info sheet styles don't get overridden on build

### DIFF
--- a/src/MainComponent.vue
+++ b/src/MainComponent.vue
@@ -632,10 +632,10 @@ video {
   .v-overlay__content {
     align-self: flex-end;
     padding: 0;
-    margin: 0;
-    max-width: 100%;
-    height: var(--info-sheet-height);
-    width: var(--info-sheet-width);
+    margin: 0 !important;
+    max-width: 100% !important;
+    height: var(--info-sheet-height) !important;
+    width: var(--info-sheet-width) !important;
   }
 
   &.info-sheet-right .v-overlay__content {


### PR DESCRIPTION
As we saw in one of our interactives (see https://github.com/cosmicds/rubin-first-look/pull/62), the info dialog styling can get overridden in the built page by the default Vuetify styling. This PR makes the necessary changes to make sure that doesn't happen.