### PR TITLE
Update noscript message

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
 
 <body>
   <noscript>
-    <strong>WorldWide Telescope requires JavaScript to run.</strong>
+    <strong>This page requires JavaScript to run.</strong>
   </noscript>
   <div id="app"></div>
   <!-- built files will be auto injected -->


### PR DESCRIPTION
The `noscript` message specifically mentions WorldWide Telescope, but there are other things in that template that need JavaScript as well, so this PR makes the message a bit more general.