### PR TITLE
Update workflows to use Percy

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.17.1'
+          node-version: "20.10.0"
 
       - name: Yarn install
         run: yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.17.1'
+          node-version: "20.10.0"
 
       - name: Yarn install
         run: yarn install
@@ -44,13 +44,33 @@ jobs:
           #     local-identifier: random
 
           # - name: Run BrowserStack tests
+          #     env:
+          #       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          #     run: |
+          #       set -xeuo pipefail
+          #       yarn serve &
+          #       sleep 10
+          #       yarn test-percy -e default,firefox,edge,safari -o reports 2>&1 | tee bslog.txt
+
+          # - name: Get Percy URL
+          #   id: percy_url
           #   run: |
-          #     set -xeuo pipefail
-          #     yarn serve &
-          #     sleep 10
-          #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+          #     URL=$(grep "percy.io" bslog.txt | awk '{print $NF}')
+          #     echo "Event type: ${{ github.event_name }}"
+          #     echo "Percy URL: $URL"
+          #     echo url=$URL >> $GITHUB_OUTPUT
 
           # - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
           #   uses: browserstack/github-actions/setup-local@master
           #   with:
           #     local-testing: stop
+          #
+
+  # comment:
+  #   if: ${{ (github.event_name == 'pull_request') || (github.event_name == 'pull_request_target') }}
+  #   needs: [build]
+  #   permissions:
+  #     pull-requests: write
+  #   uses: cosmicds/carina/.github/workflows/pr-comment.yml@main
+  #   with:
+  #     comment: "Percy diffs for commit ${{ github.event.pull_request.head.sha }} can be found at ${{ needs.build.outputs.percy_url }}"

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,27 @@
+name: PR Comment
+
+on:
+  workflow_call:
+    inputs:
+      comment:
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "${{ inputs.comment }}"
+            });


### PR DESCRIPTION
This PR updates the template workflows to use Percy, similar to what was done for Carina. Currently the testing sections are commented out as a template user may not be using BrowserStack, and this PR doesn't change that.