### PR TITLE
Add workflow for deploying dev branch

### DIFF
--- a/.github/workflows/build-deploy-dev.yml
+++ b/.github/workflows/build-deploy-dev.yml
@@ -1,111 +1,113 @@
 # Use this workflow if you want to deploy a "dev" build of the story separately at the `/dev` path
 
-# name: Build and Deploy
-# 
-# on:
-#   push:
-#     branches:
-#       - main
-#       - dev
-# 
-# jobs:
-#   build:
-#     if: ${{ github.repository_owner == 'cosmicds' }}
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v3
-#         with:
-#           persist-credentials: false
-#           ref: ${{ github.event.pull_request.head.sha }}
-# 
-#       - name: Set up Node.js
-#         uses: actions/setup-node@v6
-#         with:
-#           node-version: '20'
-# 
-#       - name: Use Yarn 4
-#         run: |
-#           corepack enable
-#           yarn set version 4.5.3
-# 
-#       - name: Yarn install
-#         run: yarn install
-# 
-#       - name: Lint
-#         run: yarn lint
-# 
-#       - name: Build
-#         run: yarn build
-#         env:
-#           VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-#           VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
-# 
-#           # - name: BrowserStack env setup
-#           #   uses: browserstack/github-actions/setup-env@master
-#           #   with:
-#           #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
-#           #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-# 
-#           # - name: BrowserStack local tunnel setup
-#           #   uses: browserstack/github-actions/setup-local@master
-#           #   with:
-#           #     local-testing: start
-#           #     local-identifier: random
-# 
-#           # - name: Run BrowserStack tests
-#           #   run: |
-#           #     set -xeuo pipefail
-#           #     yarn serve &
-#           #     sleep 10
-#           #     yarn test-bslocal -e default,firefox,edge,safari -o reports
-# 
-#       - name: Check for draft flag
-#         uses: sergeysova/jq-action@v2
-#         id: draft
-#         with:
-#           cmd: cat package.json | jq -r '.draft // false'
-# 
-#       - name: Create folder for deployment
-#         run: |
-#           mkdir deployment
-#           mkdir deployment/dev
-# 
-#       - name: Move current build to deployment
-#         id: prepare
-#         env:
-#           BRANCH: ${{ github.head_ref || github.ref_name }}
-#         run: |
-#           echo "Current branch: ${BRANCH}"
-#           [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
-#           echo "Folder to use: ${folder}"
-#           mv dist/* deployment/${folder}
-#           [[ "$BRANCH" == "dev" ]] && other="main" || other="dev"
-#           echo "Other branch: ${other}"
-#           echo "other=${other}" >> "$GITHUB_OUTPUT"
-# 
-#       - name: Check out the other branch
-#         uses: actions/checkout@v3
-#         with:
-#           ref: ${{ steps.prepare.outputs.other }}
-#           path: other
-# 
-#       - name: Build other branch and move to deployment
-#         env:
-#           BRANCH: ${{ steps.prepare.outputs.other }}
-#           VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-#           VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
-#         run: |
-#           cd other
-#           yarn install
-#           yarn build
-#           [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
-#           mv dist/* ../deployment/${folder}
-# 
-#       - name: Deploy to GitHub Pages
-#         uses: JamesIves/github-pages-deploy-action@v4
-#         if: ${{ steps.draft.outputs.value == 'false' }}
-#         with:
-#           branch: gh-pages
-#           folder: deployment 
-#           ssh-key: ${{ secrets.DEPLOY_KEY }}
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      # Uncomment these and remove "- none" when you want to use
+      - none
+      # - main
+      # - dev
+
+jobs:
+  build:
+    if: ${{ github.repository_owner == 'cosmicds' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Use Yarn 4
+        run: |
+          corepack enable
+          yarn set version 4.5.3
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build
+        env:
+          VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
+
+          # - name: BrowserStack env setup
+          #   uses: browserstack/github-actions/setup-env@master
+          #   with:
+          #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+          # - name: BrowserStack local tunnel setup
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: start
+          #     local-identifier: random
+
+          # - name: Run BrowserStack tests
+          #   run: |
+          #     set -xeuo pipefail
+          #     yarn serve &
+          #     sleep 10
+          #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+
+      - name: Check for draft flag
+        uses: sergeysova/jq-action@v2
+        id: draft
+        with:
+          cmd: cat package.json | jq -r '.draft // false'
+
+      - name: Create folder for deployment
+        run: |
+          mkdir deployment
+          mkdir deployment/dev
+
+      - name: Move current build to deployment
+        id: prepare
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: |
+          echo "Current branch: ${BRANCH}"
+          [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
+          echo "Folder to use: ${folder}"
+          mv dist/* deployment/${folder}
+          [[ "$BRANCH" == "dev" ]] && other="main" || other="dev"
+          echo "Other branch: ${other}"
+          echo "other=${other}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the other branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.prepare.outputs.other }}
+          path: other
+
+      - name: Build other branch and move to deployment
+        env:
+          BRANCH: ${{ steps.prepare.outputs.other }}
+          VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
+        run: |
+          cd other
+          yarn install
+          yarn build
+          [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
+          mv dist/* ../deployment/${folder}
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ steps.draft.outputs.value == 'false' }}
+        with:
+          branch: gh-pages
+          folder: deployment 
+          ssh-key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/build-deploy-dev.yml
+++ b/.github/workflows/build-deploy-dev.yml
@@ -1,0 +1,111 @@
+# Use this workflow if you want to deploy a "dev" build of the story separately at the `/dev` path
+
+# name: Build and Deploy
+# 
+# on:
+#   push:
+#     branches:
+#       - main
+#       - dev
+# 
+# jobs:
+#   build:
+#     if: ${{ github.repository_owner == 'cosmicds' }}
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v3
+#         with:
+#           persist-credentials: false
+#           ref: ${{ github.event.pull_request.head.sha }}
+# 
+#       - name: Set up Node.js
+#         uses: actions/setup-node@v6
+#         with:
+#           node-version: '20'
+# 
+#       - name: Use Yarn 4
+#         run: |
+#           corepack enable
+#           yarn set version 4.5.3
+# 
+#       - name: Yarn install
+#         run: yarn install
+# 
+#       - name: Lint
+#         run: yarn lint
+# 
+#       - name: Build
+#         run: yarn build
+#         env:
+#           VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+#           VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
+# 
+#           # - name: BrowserStack env setup
+#           #   uses: browserstack/github-actions/setup-env@master
+#           #   with:
+#           #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+#           #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+# 
+#           # - name: BrowserStack local tunnel setup
+#           #   uses: browserstack/github-actions/setup-local@master
+#           #   with:
+#           #     local-testing: start
+#           #     local-identifier: random
+# 
+#           # - name: Run BrowserStack tests
+#           #   run: |
+#           #     set -xeuo pipefail
+#           #     yarn serve &
+#           #     sleep 10
+#           #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+# 
+#       - name: Check for draft flag
+#         uses: sergeysova/jq-action@v2
+#         id: draft
+#         with:
+#           cmd: cat package.json | jq -r '.draft // false'
+# 
+#       - name: Create folder for deployment
+#         run: |
+#           mkdir deployment
+#           mkdir deployment/dev
+# 
+#       - name: Move current build to deployment
+#         id: prepare
+#         env:
+#           BRANCH: ${{ github.head_ref || github.ref_name }}
+#         run: |
+#           echo "Current branch: ${BRANCH}"
+#           [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
+#           echo "Folder to use: ${folder}"
+#           mv dist/* deployment/${folder}
+#           [[ "$BRANCH" == "dev" ]] && other="main" || other="dev"
+#           echo "Other branch: ${other}"
+#           echo "other=${other}" >> "$GITHUB_OUTPUT"
+# 
+#       - name: Check out the other branch
+#         uses: actions/checkout@v3
+#         with:
+#           ref: ${{ steps.prepare.outputs.other }}
+#           path: other
+# 
+#       - name: Build other branch and move to deployment
+#         env:
+#           BRANCH: ${{ steps.prepare.outputs.other }}
+#           VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+#           VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
+#         run: |
+#           cd other
+#           yarn install
+#           yarn build
+#           [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
+#           mv dist/* ../deployment/${folder}
+# 
+#       - name: Deploy to GitHub Pages
+#         uses: JamesIves/github-pages-deploy-action@v4
+#         if: ${{ steps.draft.outputs.value == 'false' }}
+#         with:
+#           branch: gh-pages
+#           folder: deployment 
+#           ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
This PR adds a workflow for deploying a `dev` branch to the `/dev` path on GitHub Pages. The workflow has logic that checks the current branch and adjusts appropriately, so we can run the same workflow on `main` or `dev`.

For convenience, this workflow is marked to run on the nonexistent `none` branch so that it doesn't run by default, but is in the working tree if needed.